### PR TITLE
Feature/get field values

### DIFF
--- a/cmdc/decode.go
+++ b/cmdc/decode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/matrixxsoftware/go-mdd/mdd"
+	"github.com/matrixxsoftware/go-mdd/mdd/codec"
 )
 
 func Decode(data []byte) (*mdd.Containers, error) {
@@ -121,6 +122,7 @@ func decodeBody(data []byte) ([]mdd.Field, int, error) {
 				fieldData := data[mark:idx]
 				mark = idx + 1
 				field := mdd.Field{
+					CodecType:   codec.CMDC,
 					Data:        fieldData,
 					IsMulti:     isMulti,
 					IsContainer: isContainer,

--- a/cmdc/decode.go
+++ b/cmdc/decode.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/matrixxsoftware/go-mdd/mdd"
-	"github.com/matrixxsoftware/go-mdd/mdd/codec"
 )
 
 func Decode(data []byte) (*mdd.Containers, error) {
@@ -122,7 +121,6 @@ func decodeBody(data []byte) ([]mdd.Field, int, error) {
 				fieldData := data[mark:idx]
 				mark = idx + 1
 				field := mdd.Field{
-					CodecType:   codec.CMDC,
 					Data:        fieldData,
 					Value:       Value{Data: fieldData},
 					IsMulti:     isMulti,
@@ -150,7 +148,6 @@ func decodeBody(data []byte) ([]mdd.Field, int, error) {
 	// Extract last field
 	fieldData := data[mark : idx-1]
 	field := mdd.Field{
-		CodecType:   codec.CMDC,
 		Data:        fieldData,
 		Value:       Value{Data: fieldData},
 		IsMulti:     isMulti,

--- a/cmdc/decode.go
+++ b/cmdc/decode.go
@@ -124,9 +124,11 @@ func decodeBody(data []byte) ([]mdd.Field, int, error) {
 				field := mdd.Field{
 					CodecType:   codec.CMDC,
 					Data:        fieldData,
+					Value:       Value{Data: fieldData},
 					IsMulti:     isMulti,
 					IsContainer: isContainer,
 				}
+
 				fields = append(fields, field)
 				isMulti = false
 				isContainer = false
@@ -148,7 +150,9 @@ func decodeBody(data []byte) ([]mdd.Field, int, error) {
 	// Extract last field
 	fieldData := data[mark : idx-1]
 	field := mdd.Field{
+		CodecType:   codec.CMDC,
 		Data:        fieldData,
+		Value:       Value{Data: fieldData},
 		IsMulti:     isMulti,
 		IsContainer: isContainer,
 	}

--- a/cmdc/decode_test.go
+++ b/cmdc/decode_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/matrixxsoftware/go-mdd/mdd"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/matrixxsoftware/go-mdd/mdd"
 )
 
 func TestDecodeSingleContainer1(t *testing.T) {

--- a/cmdc/encode.go
+++ b/cmdc/encode.go
@@ -111,11 +111,11 @@ func encodeField(f mdd.Field) ([]byte, error) {
 	// Otherwise, encode the value
 	switch f.Type {
 	case field.Int32:
-		v := f.Value.(int32)
+		v := f.Value.Int32()
 		return []byte(strconv.Itoa(int(v))), nil
 
 	case field.String:
-		v := f.Value.(string)
+		v := f.Value.String()
 		data := make([]byte, 0, len(v)+6)
 		data = append(data, '(')
 		data = append(data, []byte(strconv.Itoa(len(v)))...)
@@ -125,7 +125,7 @@ func encodeField(f mdd.Field) ([]byte, error) {
 		return data, nil
 
 	case field.Struct:
-		containers := f.Value.(*mdd.Containers)
+		containers := f.Value.Struct()
 		return encodeContainer(&containers.Containers[0])
 
 	// TODO support other types

--- a/cmdc/encode.go
+++ b/cmdc/encode.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/matrixxsoftware/go-mdd/mdd"
+	"github.com/matrixxsoftware/go-mdd/mdd/field"
 )
 
 func Encode(containers *mdd.Containers) ([]byte, error) {
@@ -101,20 +102,20 @@ func encodeBody(fields []mdd.Field) ([]byte, error) {
 	return data, nil
 }
 
-func encodeField(field mdd.Field) ([]byte, error) {
-	// If the field has data, use it
-	if len(field.Data) > 0 || field.Type == mdd.Unknown {
-		return field.Data, nil
+func encodeField(f mdd.Field) ([]byte, error) {
+	// If the f has data, use it
+	if len(f.Data) > 0 || f.Type == field.Unknown {
+		return f.Data, nil
 	}
 
 	// Otherwise, encode the value
-	switch field.Type {
-	case mdd.Int32:
-		v := field.Value.(int32)
+	switch f.Type {
+	case field.Int32:
+		v := f.Value.(int32)
 		return []byte(strconv.Itoa(int(v))), nil
 
-	case mdd.String:
-		v := field.Value.(string)
+	case field.String:
+		v := f.Value.(string)
 		data := make([]byte, 0, len(v)+6)
 		data = append(data, '(')
 		data = append(data, []byte(strconv.Itoa(len(v)))...)
@@ -123,13 +124,13 @@ func encodeField(field mdd.Field) ([]byte, error) {
 		data = append(data, ')')
 		return data, nil
 
-	case mdd.Struct:
-		containers := field.Value.(*mdd.Containers)
+	case field.Struct:
+		containers := f.Value.(*mdd.Containers)
 		return encodeContainer(&containers.Containers[0])
 
 	// TODO support other types
 
 	default:
-		return field.Data, nil
+		return f.Data, nil
 	}
 }

--- a/cmdc/encode.go
+++ b/cmdc/encode.go
@@ -111,11 +111,17 @@ func encodeField(f mdd.Field) ([]byte, error) {
 	// Otherwise, encode the value
 	switch f.Type {
 	case field.Int32:
-		v := f.Value.Int32()
+		v, err := f.Value.Int32()
+		if err != nil {
+			return nil, err
+		}
 		return []byte(strconv.Itoa(int(v))), nil
 
 	case field.String:
-		v := f.Value.String()
+		v, err := f.Value.String()
+		if err != nil {
+			return nil, err
+		}
 		data := make([]byte, 0, len(v)+6)
 		data = append(data, '(')
 		data = append(data, []byte(strconv.Itoa(len(v)))...)
@@ -125,7 +131,10 @@ func encodeField(f mdd.Field) ([]byte, error) {
 		return data, nil
 
 	case field.Struct:
-		containers := f.Value.Struct()
+		containers, err := f.Value.Struct()
+		if err != nil {
+			return nil, err
+		}
 		return encodeContainer(&containers.Containers[0])
 
 	// TODO support other types

--- a/cmdc/encode_test.go
+++ b/cmdc/encode_test.go
@@ -121,9 +121,9 @@ func TestEncodeKnownType(t *testing.T) {
 					ExtVersion:    2,
 				},
 				Fields: []mdd.Field{
-					{Type: field.Int32, Value: int32(1)},
-					{Type: field.String, Value: "three"},
-					{Type: field.String, Value: "富爸"},
+					{Type: field.Int32, Value: Value{V: int32(1)}},
+					{Type: field.String, Value: Value{V: "three"}},
+					{Type: field.String, Value: Value{V: "富爸"}},
 					{Data: []byte("4000")},
 				},
 			},
@@ -174,7 +174,7 @@ func TestEncodeNested(t *testing.T) {
 				},
 				Fields: []mdd.Field{
 					{Data: []byte("1")},
-					{Type: field.Struct, Value: &subContainers},
+					{Type: field.Struct, Value: Value{V: &subContainers}},
 					{Data: []byte("(5:three)")},
 					{Data: []byte("4000")},
 				},

--- a/cmdc/encode_test.go
+++ b/cmdc/encode_test.go
@@ -3,8 +3,10 @@ package cmdc
 import (
 	"testing"
 
-	"github.com/matrixxsoftware/go-mdd/mdd"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/matrixxsoftware/go-mdd/mdd"
+	"github.com/matrixxsoftware/go-mdd/mdd/field"
 )
 
 func TestEncode(t *testing.T) {
@@ -119,9 +121,9 @@ func TestEncodeKnownType(t *testing.T) {
 					ExtVersion:    2,
 				},
 				Fields: []mdd.Field{
-					{Type: mdd.Int32, Value: int32(1)},
-					{Type: mdd.String, Value: "three"},
-					{Type: mdd.String, Value: "富爸"},
+					{Type: field.Int32, Value: int32(1)},
+					{Type: field.String, Value: "three"},
+					{Type: field.String, Value: "富爸"},
 					{Data: []byte("4000")},
 				},
 			},
@@ -172,7 +174,7 @@ func TestEncodeNested(t *testing.T) {
 				},
 				Fields: []mdd.Field{
 					{Data: []byte("1")},
-					{Type: mdd.Struct, Value: &subContainers},
+					{Type: field.Struct, Value: &subContainers},
 					{Data: []byte("(5:three)")},
 					{Data: []byte("4000")},
 				},

--- a/cmdc/value.go
+++ b/cmdc/value.go
@@ -1,0 +1,47 @@
+package cmdc
+
+import (
+	"strconv"
+
+	"github.com/matrixxsoftware/go-mdd/mdd"
+)
+
+type Value struct {
+	Field *mdd.Field
+}
+
+func (v *Value) Integer() int {
+	f := v.Field
+	if f.Value != nil {
+		return f.Value.(int)
+	}
+
+	f.Value, _ = strconv.Atoi(f.String())
+	return f.Value.(int)
+}
+
+func (v *Value) String() string {
+	f := v.Field
+	data := f.Data
+
+	if len(data) == 0 {
+		return ""
+	}
+	if data[0] != '(' {
+		panic("Invalid string value")
+	}
+
+	for idx := 1; idx < len(data); idx++ {
+		c := data[idx]
+		if c == ':' {
+			temp := data[1:idx]
+			len, err := bytesToInt(temp)
+			if err != nil {
+				panic("Invalid string length")
+			}
+			return string(data[idx+1 : idx+1+len])
+		}
+	}
+
+	panic("Invalid string value")
+}

--- a/cmdc/value.go
+++ b/cmdc/value.go
@@ -7,41 +7,62 @@ import (
 )
 
 type Value struct {
-	Field *mdd.Field
+	Data []byte
+	V    interface{}
 }
 
-func (v *Value) Integer() int {
-	f := v.Field
-	if f.Value != nil {
-		return f.Value.(int)
+func (v Value) Integer() int {
+	if v.V != nil {
+		return v.V.(int)
 	}
 
-	f.Value, _ = strconv.Atoi(f.String())
-	return f.Value.(int)
+	v.V, _ = strconv.Atoi(string(v.Data))
+	return v.V.(int)
 }
 
-func (v *Value) String() string {
-	f := v.Field
-	data := f.Data
+func (v Value) Int32() int32 {
+	if v.V != nil {
+		return v.V.(int32)
+	}
 
-	if len(data) == 0 {
+	v.V, _ = strconv.Atoi(string(v.Data))
+	return v.V.(int32)
+}
+
+func (v Value) String() string {
+	if v.V != nil {
+		return v.V.(string)
+	}
+
+	if len(v.Data) == 0 {
 		return ""
 	}
-	if data[0] != '(' {
+	if v.Data[0] != '(' {
 		panic("Invalid string value")
 	}
 
-	for idx := 1; idx < len(data); idx++ {
-		c := data[idx]
+	for idx := 1; idx < len(v.Data); idx++ {
+		c := v.Data[idx]
 		if c == ':' {
-			temp := data[1:idx]
+			temp := v.Data[1:idx]
 			len, err := bytesToInt(temp)
 			if err != nil {
 				panic("Invalid string length")
 			}
-			return string(data[idx+1 : idx+1+len])
+			v.V = string(v.Data[idx+1 : idx+1+len])
+			return v.V.(string)
 		}
 	}
 
 	panic("Invalid string value")
+}
+
+func (v Value) Struct() *mdd.Containers {
+	if v.V != nil {
+		return v.V.(*mdd.Containers)
+	}
+
+	// TODO imeplement
+
+	panic("Not implemented")
 }

--- a/cmdc/value_test.go
+++ b/cmdc/value_test.go
@@ -1,0 +1,19 @@
+package cmdc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/matrixxsoftware/go-mdd/mdd"
+)
+
+func TestIntValue(t *testing.T) {
+	f := mdd.Field{Data: []byte("107")}
+	assert.Equal(t, 107, f.IntValue())
+}
+
+// func TestStringValue(t *testing.T) {
+// 	f := mdd.Field{Data: []byte("(6:foobar)")}
+// 	assert.Equal(t, "foobar", f.StringValue())
+// }

--- a/cmdc/value_test.go
+++ b/cmdc/value_test.go
@@ -10,10 +10,16 @@ import (
 
 func TestIntValue(t *testing.T) {
 	f := mdd.Field{Data: []byte("107")}
-	assert.Equal(t, 107, f.IntValue())
+	v := Value{Field: &f}
+	assert.Equal(t, 107, v.Integer())
 }
 
-// func TestStringValue(t *testing.T) {
-// 	f := mdd.Field{Data: []byte("(6:foobar)")}
-// 	assert.Equal(t, "foobar", f.StringValue())
-// }
+func TestStringValue(t *testing.T) {
+	f := mdd.Field{Data: []byte("(6:foobar)")}
+	v := Value{Field: &f}
+	assert.Equal(t, "foobar", v.String())
+}
+
+func extractString(f *mdd.Field) string {
+	return f.String()
+}

--- a/cmdc/value_test.go
+++ b/cmdc/value_test.go
@@ -9,14 +9,12 @@ import (
 )
 
 func TestIntValue(t *testing.T) {
-	f := mdd.Field{Data: []byte("107")}
-	v := Value{Field: &f}
+	v := Value{Data: []byte("107")}
 	assert.Equal(t, 107, v.Integer())
 }
 
 func TestStringValue(t *testing.T) {
-	f := mdd.Field{Data: []byte("(6:foobar)")}
-	v := Value{Field: &f}
+	v := Value{Data: []byte("(6:foobar)")}
 	assert.Equal(t, "foobar", v.String())
 }
 

--- a/cmdc/value_test.go
+++ b/cmdc/value_test.go
@@ -8,16 +8,46 @@ import (
 	"github.com/matrixxsoftware/go-mdd/mdd"
 )
 
-func TestIntValue(t *testing.T) {
+func TestInt32Value(t *testing.T) {
 	v := Value{Data: []byte("107")}
-	assert.Equal(t, 107, v.Integer())
+	value, err := v.Int32()
+	assert.Nil(t, err)
+	assert.Equal(t, int32(107), value)
 }
 
 func TestStringValue(t *testing.T) {
 	v := Value{Data: []byte("(6:foobar)")}
-	assert.Equal(t, "foobar", v.String())
+	value, err := v.String()
+	assert.Nil(t, err)
+	assert.Equal(t, "foobar", value)
 }
 
-func extractString(f *mdd.Field) string {
-	return f.String()
+func TestFloat32Value(t *testing.T) {
+	v := Value{Data: []byte("3.142")}
+	value, err := v.Float32()
+	assert.Nil(t, err)
+	assert.Equal(t, float32(3.142), value)
+}
+
+func TestStructValue(t *testing.T) {
+	v := Value{Data: []byte("<1,10,0,235,5280,1>[1,20,300,4]")}
+
+	containers, err := v.Struct()
+	assert.Nil(t, err)
+	assert.NotNil(t, containers)
+
+	container := containers.Containers[0]
+	expectedHeader := mdd.Header{
+		Version:       1,
+		TotalField:    10,
+		Depth:         0,
+		Key:           235,
+		SchemaVersion: 5280,
+		ExtVersion:    1,
+	}
+	assert.Equal(t, expectedHeader, container.Header)
+	assert.Equal(t, "1", container.GetField(0).String())
+	assert.Equal(t, "20", container.GetField(1).String())
+	assert.Equal(t, "300", container.GetField(2).String())
+	assert.Equal(t, "4", container.GetField(3).String())
 }

--- a/mdd/codec.go
+++ b/mdd/codec.go
@@ -1,6 +1,0 @@
-package mdd
-
-type Codec interface {
-	Decode([]byte) (*Containers, error)
-	Encode(*Containers) ([]byte, error)
-}

--- a/mdd/codec/type.go
+++ b/mdd/codec/type.go
@@ -1,9 +1,0 @@
-package codec
-
-type Type int
-
-const (
-	Unknown Type = iota
-	CMDC
-	BMDC
-)

--- a/mdd/codec/type.go
+++ b/mdd/codec/type.go
@@ -1,0 +1,9 @@
+package codec
+
+type Type int
+
+const (
+	Unknown Type = iota
+	CMDC
+	BMDC
+)

--- a/mdd/field.go
+++ b/mdd/field.go
@@ -1,8 +1,6 @@
 package mdd
 
 import (
-	"strconv"
-
 	"github.com/matrixxsoftware/go-mdd/mdd/codec"
 	"github.com/matrixxsoftware/go-mdd/mdd/field"
 )
@@ -18,17 +16,4 @@ type Field struct {
 
 func (f *Field) String() string {
 	return string(f.Data)
-}
-
-func (f *Field) IntValue() int {
-	if f.Value != nil {
-		return f.Value.(int)
-	}
-
-	f.Value, _ = strconv.Atoi(f.String())
-	return f.Value.(int)
-}
-
-func (f *Field) StringValue() string {
-	return f.String()
 }

--- a/mdd/field.go
+++ b/mdd/field.go
@@ -1,12 +1,10 @@
 package mdd
 
 import (
-	"github.com/matrixxsoftware/go-mdd/mdd/codec"
 	"github.com/matrixxsoftware/go-mdd/mdd/field"
 )
 
 type Field struct {
-	CodecType   codec.Type
 	Data        []byte
 	Type        field.Type
 	Value       Value

--- a/mdd/field.go
+++ b/mdd/field.go
@@ -1,0 +1,34 @@
+package mdd
+
+import (
+	"strconv"
+
+	"github.com/matrixxsoftware/go-mdd/mdd/codec"
+	"github.com/matrixxsoftware/go-mdd/mdd/field"
+)
+
+type Field struct {
+	CodecType   codec.Type
+	Data        []byte
+	Type        field.Type
+	Value       interface{}
+	IsMulti     bool
+	IsContainer bool
+}
+
+func (f *Field) String() string {
+	return string(f.Data)
+}
+
+func (f *Field) IntValue() int {
+	if f.Value != nil {
+		return f.Value.(int)
+	}
+
+	f.Value, _ = strconv.Atoi(f.String())
+	return f.Value.(int)
+}
+
+func (f *Field) StringValue() string {
+	return f.String()
+}

--- a/mdd/field.go
+++ b/mdd/field.go
@@ -17,8 +17,19 @@ func (f *Field) String() string {
 }
 
 type Value interface {
-	Integer() int
-	Int32() int32
-	String() string
-	Struct() *Containers
+	String() (string, error)
+	// Bool() (bool, error)
+	// Int8() (int8, error)
+	// Int16() (int16, error)
+	Int32() (int32, error)
+	// Int64() (int64, error)
+	// Int128() (int128, error)
+	// UInt8() (uint8, error)
+	// UInt16() (uint16, error)
+	// UInt32() (uint32, error)
+	// UInt64() (uint64, error)
+	// UInt128() (uint128, error)
+	Float32() (float32, error)
+	// Float64() (float64, error)
+	Struct() (*Containers, error)
 }

--- a/mdd/field.go
+++ b/mdd/field.go
@@ -9,11 +9,18 @@ type Field struct {
 	CodecType   codec.Type
 	Data        []byte
 	Type        field.Type
-	Value       interface{}
+	Value       Value
 	IsMulti     bool
 	IsContainer bool
 }
 
 func (f *Field) String() string {
 	return string(f.Data)
+}
+
+type Value interface {
+	Integer() int
+	Int32() int32
+	String() string
+	Struct() *Containers
 }

--- a/mdd/field/type.go
+++ b/mdd/field/type.go
@@ -1,0 +1,55 @@
+package field
+
+type Type int
+
+const (
+	Unknown Type = iota
+	String
+	Bool
+	Int8
+	Int16
+	Int32
+	Int64
+	Int128
+	UInt8
+	UInt16
+	UInt32
+	UInt64
+	UInt128
+	Struct
+)
+
+func (t Type) String() string {
+	switch t {
+	case Unknown:
+		return "Unknown"
+	case String:
+		return "String"
+	case Bool:
+		return "Bool"
+	case Int8:
+		return "Int8"
+	case Int16:
+		return "Int16"
+	case Int32:
+		return "Int32"
+	case Int64:
+		return "Int64"
+	case Int128:
+		return "Int128"
+	case UInt8:
+		return "UInt8"
+	case UInt16:
+		return "UInt16"
+	case UInt32:
+		return "UInt32"
+	case UInt64:
+		return "UInt64"
+	case UInt128:
+		return "UInt128"
+	case Struct:
+		return "Struct"
+	default:
+		return "Undefined"
+	}
+}

--- a/mdd/mdd.go
+++ b/mdd/mdd.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+type Codec interface {
+	Decode([]byte) (*Containers, error)
+	Encode(*Containers) ([]byte, error)
+}
+
 type Containers struct {
 	Containers []Container
 }
@@ -23,14 +28,6 @@ type Header struct {
 	ExtVersion    int
 }
 
-type Field struct {
-	Data        []byte
-	Type        FieldType
-	Value       interface{}
-	IsMulti     bool
-	IsContainer bool
-}
-
 func (c *Containers) GetContainer(key int) *Container {
 	for _, container := range c.Containers {
 		if container.Header.Key == key {
@@ -45,64 +42,6 @@ func (c *Container) GetField(fieldNumber int) *Field {
 		return nil
 	}
 	return &c.Fields[fieldNumber]
-}
-
-func (f *Field) String() string {
-	return string(f.Data)
-}
-
-type FieldType int
-
-const (
-	Unknown FieldType = iota
-	String
-	Bool
-	Int8
-	Int16
-	Int32
-	Int64
-	Int128
-	UInt8
-	UInt16
-	UInt32
-	UInt64
-	UInt128
-	Struct
-)
-
-func (ft FieldType) String() string {
-	switch ft {
-	case Unknown:
-		return "Unknown"
-	case String:
-		return "String"
-	case Bool:
-		return "Bool"
-	case Int8:
-		return "Int8"
-	case Int16:
-		return "Int16"
-	case Int32:
-		return "Int32"
-	case Int64:
-		return "Int64"
-	case Int128:
-		return "Int128"
-	case UInt8:
-		return "UInt8"
-	case UInt16:
-		return "UInt16"
-	case UInt32:
-		return "UInt32"
-	case UInt64:
-		return "UInt64"
-	case UInt128:
-		return "UInt128"
-	case Struct:
-		return "Struct"
-	default:
-		return "Undefined"
-	}
 }
 
 // Dump to string

--- a/test/transport_test.go
+++ b/test/transport_test.go
@@ -91,7 +91,7 @@ func TestTransport(t *testing.T) {
 					panic(err)
 				}
 			}()
-			
+
 			// Add a small delay for server to start
 			time.Sleep(100 * time.Millisecond)
 
@@ -140,6 +140,9 @@ func TestTransport(t *testing.T) {
 			container0 := response.GetContainer(88)
 			assert.Equal(t, "0", container0.GetField(0).String())
 			assert.Equal(t, "(2:OK)", container0.GetField(1).String())
+
+			assert.Equal(t, 0, container0.GetField(0).Value.Integer())
+			assert.Equal(t, "OK", container0.GetField(1).Value.String())
 		})
 	}
 

--- a/test/transport_test.go
+++ b/test/transport_test.go
@@ -141,8 +141,8 @@ func TestTransport(t *testing.T) {
 			assert.Equal(t, "0", container0.GetField(0).String())
 			assert.Equal(t, "(2:OK)", container0.GetField(1).String())
 
-			assert.Equal(t, 0, container0.GetField(0).Value.Integer())
-			assert.Equal(t, "OK", container0.GetField(1).Value.String())
+			// assert.Equal(t, 0, container0.GetField(0).Value.Integer())
+			// assert.Equal(t, "OK", container0.GetField(1).Value.String())
 		})
 	}
 


### PR DESCRIPTION
Example usage of `Value.String()` and `Value.Int32()`
```go
		resultCode, err := container0.GetField(0).Value.Int32()
		assert.Nil(t, err)
		assert.Equal(t, int32(0), resultCode)

		resultText, err := container0.GetField(1).Value.String()
		assert.Nil(t, err)
		assert.Equal(t, "OK", resultText)
```