### PR TITLE
skip mdd casting in container if matrixxVersion and extVersion is same

### DIFF
--- a/mdd/mdd.go
+++ b/mdd/mdd.go
@@ -69,6 +69,13 @@ func (c *Containers) CastVersion(definitions *dictionary.Dictionary, schemaVersi
 	newContainers := &Containers{}
 	for i := range c.Containers {
 		container := &c.Containers[i]
+
+		// skip cast if version same
+		if container.Header.SchemaVersion == schemaVersion && container.Header.ExtVersion == extVersion {
+			newContainers.Containers = append(newContainers.Containers, *container)
+			continue
+		}
+
 		targetDefinition, err := definitions.Lookup(
 			container.Header.Key,
 			schemaVersion,

--- a/mdd/mdd_test.go
+++ b/mdd/mdd_test.go
@@ -1,6 +1,7 @@
 package mdd
 
 import (
+	"encoding/xml"
 	"strconv"
 	"testing"
 
@@ -191,6 +192,109 @@ func TestCastVersion(t *testing.T) {
 	assert.Nil(t, v)
 
 	v, err = newContainer.GetField(3).GetValue()
+	assert.Nil(t, err)
+	assert.Equal(t, int32(-1877540863), v)
+}
+
+func TestCastVersionWithOldVersion(t *testing.T) {
+
+	container := &Container{
+		Header: Header{
+			Version:       1,
+			TotalField:    3,
+			Depth:         0,
+			Key:           10101,
+			SchemaVersion: 5263,
+			ExtVersion:    13,
+		},
+		Fields: []Field{
+			*NewBasicField("aaa"),
+			*NewNullField(field.DateTime),
+			*NewBasicField(int32(-1877540863)),
+		},
+		Definition: &dictionary.ContainerDefinition{
+			Key:           10101,
+			Name:          "TestContainer",
+			SchemaVersion: 5263,
+			ExtVersion:    13,
+			Fields: []dictionary.FieldDefinition{
+				{Name: "Field1", Type: field.String},
+				{Name: "Field2", Type: field.DateTime},
+				{Name: "Field3", Type: field.Int32},
+			},
+		},
+	}
+	containers := Containers{
+		Containers: []Container{
+			*container,
+		},
+	}
+
+	t.Logf("Original containers \n%s\n", containers.Dump())
+
+	// old schema with lesser field
+	matrixxSchema := &dictionary.Configuration{
+		Name:     xml.Name{Space: "", Local: "configuration"},
+		Subtypes: nil,
+		Containers: []dictionary.Container{
+			{
+				ID:                   "TestContainer",
+				DocDescription:       "Test Container",
+				Key:                  10101,
+				CreatedSchemaVersion: 5260,
+				DeletedSchemaVersion: 0,
+				Fields: []dictionary.Field{
+					{
+						ID:                   "Field1",
+						DocDescription:       "Field 1",
+						Datatype:             "string",
+						IsArray:              false,
+						IsList:               false,
+						StructID:             "",
+						SubTypeReference:     "",
+						CreatedSchemaVersion: 5263,
+						DeletedSchemaVersion: 0,
+					},
+					{
+						ID:                   "Field2",
+						DocDescription:       "Field 2",
+						Datatype:             "datetime",
+						IsArray:              false,
+						IsList:               false,
+						StructID:             "",
+						SubTypeReference:     "",
+						CreatedSchemaVersion: 5263,
+						DeletedSchemaVersion: 0,
+					},
+				},
+			},
+		},
+	}
+	definitions := dictionary.NewWithSchema(matrixxSchema, nil)
+
+	newContainers, err := containers.CastVersion(definitions, 5263, 13)
+	assert.Nil(t, err)
+	t.Logf("New version casted containers: \n%s\n", newContainers.Dump())
+
+	assert.Equal(t, 1, len(newContainers.Containers))
+	newContainer := newContainers.GetContainer(10101)
+	assert.NotNil(t, newContainer)
+
+	assert.Equal(t, 10101, newContainer.Header.Key)
+	assert.Equal(t, 5263, newContainer.Header.SchemaVersion)
+	assert.Equal(t, 13, newContainer.Header.ExtVersion)
+	assert.Equal(t, 3, newContainer.Header.TotalField)
+	assert.Equal(t, 3, len(newContainer.Fields))
+
+	v, err := newContainer.GetField(0).GetValue()
+	assert.Nil(t, err)
+	assert.Equal(t, "aaa", v)
+
+	v, err = newContainer.GetField(1).GetValue()
+	assert.Nil(t, err)
+	assert.Nil(t, v)
+
+	v, err = newContainer.GetField(2).GetValue()
 	assert.Nil(t, err)
 	assert.Equal(t, int32(-1877540863), v)
 }


### PR DESCRIPTION
To prevent issue where Dictionary loaded is outdated and have lesser fields compared to mdd containers wish to cast, the fields that missing will lost from casting process